### PR TITLE
Add Mapping functions for email and name

### DIFF
--- a/taiga_contrib_ldap_auth_ext/services.py
+++ b/taiga_contrib_ldap_auth_ext/services.py
@@ -26,6 +26,8 @@ from . import connector
 FALLBACK = getattr(settings, "LDAP_FALLBACK", "")
 
 SLUGIFY = getattr(settings, 'LDAP_MAP_USERNAME_TO_UID', '')
+EMAIL_MAP = getattr(settings, 'LDAP_MAP_EMAIL', '')
+NAME_MAP = getattr(settings, 'LDAP_MAP_NAME', '')
 
 
 def ldap_login_func(request):
@@ -74,7 +76,14 @@ def register_or_update(username: str, email: str, full_name: str):
 
     username_unique = username
     if SLUGIFY:
-        username_unique = SLUGIFY(username)
+        username_unique = SLUGIFY(username)        
+        
+    if EMAIL_MAP:
+        email = EMAIL_MAP(email)
+
+        
+    if NAME_MAP:
+        full_name = NAME_MAP(full_name)
 
     try:
         # has user logged in before?


### PR DESCRIPTION
Similar to the SLUGIFY method, which allows a configurable modifier for the username, this commit implements an option to apply similar mappers to the name and email as well.

An excellent example of the mapper would be converting email to lowercase.