### PR TITLE
fix #26 add an option to save or not the ldap password

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ LDAP_USERNAME_ATTRIBUTE = 'uid'
 LDAP_EMAIL_ATTRIBUTE = 'mail'
 LDAP_FULL_NAME_ATTRIBUTE = 'displayName'
 
+# Option to not store the passwords in the local db
+#LDAP_SAVE_LOGIN_PASSWORD = False
+
 # TODO https://github.com/Monogramm/taiga-contrib-ldap-auth-ext/issues/15
 # Group search filter where $1 is the project slug and $2 is the role slug
 #LDAP_GROUP_SEARCH_FILTER = 'CN=$2,OU=$1,OU=Groups,DC=example,DC=net'

--- a/taiga_contrib_ldap_auth_ext/services.py
+++ b/taiga_contrib_ldap_auth_ext/services.py
@@ -29,7 +29,7 @@ FALLBACK = getattr(settings, 'LDAP_FALLBACK', 'normal')
 SLUGIFY = getattr(settings, 'LDAP_MAP_USERNAME_TO_UID', '')
 EMAIL_MAP = getattr(settings, 'LDAP_MAP_EMAIL', '')
 NAME_MAP = getattr(settings, 'LDAP_MAP_NAME', '')
-SAVE_USER = getattr(settings, 'LDAP_SAVE_LOGIN__PASSWORD', True)
+SAVE_USER = getattr(settings, 'LDAP_SAVE_LOGIN_PASSWORD', True)
 
 # TODO https://github.com/Monogramm/taiga-contrib-ldap-auth-ext/issues/17
 # Taiga super users group id
@@ -116,8 +116,6 @@ def register_or_update(username: str, email: str, full_name: str, password: str)
         if SAVE_USER:
             # Set local password to match LDAP (issues/21)
             user.set_password(password)
-        else:
-            user.set_password('')
 
         user.save()
 
@@ -128,7 +126,7 @@ def register_or_update(username: str, email: str, full_name: str, password: str)
             # Set local password to match LDAP (issues/21)
             user.set_password(password)
         else:
-            user.set_password('')
+            user.set_password(None)
         user.save()
         # update DB entry if LDAP field values differ
         if user.email != email or user.full_name != full_name:


### PR DESCRIPTION
I create an option to save or not the ldap password. 
The option is defined in the beginning of the services.py. If the user already exists, the password is set to nil else the password is updated (_case of LDAP password updated_). 