### PR TITLE
Sanitize data before passing to ldap

### DIFF
--- a/taiga_contrib_ldap_auth_ext/connector.py
+++ b/taiga_contrib_ldap_auth_ext/connector.py
@@ -14,6 +14,7 @@
 from ldap3 import Server, Connection, AUTO_BIND_NO_TLS, AUTO_BIND_TLS_BEFORE_BIND, ANONYMOUS, SIMPLE, SYNC, SUBTREE, NONE
 
 from django.conf import settings
+from ldap3.utils.conv import escape_filter_chars
 from taiga.base.connectors.exceptions import ConnectorBaseException
 
 
@@ -101,9 +102,9 @@ def login(username: str, password: str) -> tuple:
         raise LDAPConnectionError({"error_message": error})
 
     # search for user-provided login
-    # TODO The username should be sanitized to prevent LDAP injection
+    username_sanitized = escape_filter_chars(username)
     search_filter = '(|(%s=%s)(%s=%s))' % (
-        USERNAME_ATTRIBUTE, username, EMAIL_ATTRIBUTE, username)
+        USERNAME_ATTRIBUTE, username_sanitized, EMAIL_ATTRIBUTE, username_sanitized)
     if SEARCH_FILTER_ADDITIONAL:
         search_filter = '(&%s%s)' % (search_filter, SEARCH_FILTER_ADDITIONAL)
     try:

--- a/taiga_contrib_ldap_auth_ext/connector.py
+++ b/taiga_contrib_ldap_auth_ext/connector.py
@@ -57,6 +57,8 @@ def login(username: str, password: str) -> tuple:
     Can raise `exc.LDAPUserLoginError` exceptions if the
     login to LDAP fails.
 
+    :param username: a possibly unsanitized username
+    :param password: a possibly unsanitized password
     :returns: tuple (username, email, full_name)
 
     """
@@ -99,6 +101,7 @@ def login(username: str, password: str) -> tuple:
         raise LDAPConnectionError({"error_message": error})
 
     # search for user-provided login
+    # TODO The username should be sanitized to prevent LDAP injection
     search_filter = '(|(%s=%s)(%s=%s))' % (
         USERNAME_ATTRIBUTE, username, EMAIL_ATTRIBUTE, username)
     if SEARCH_FILTER_ADDITIONAL:

--- a/taiga_contrib_ldap_auth_ext/services.py
+++ b/taiga_contrib_ldap_auth_ext/services.py
@@ -55,7 +55,6 @@ def ldap_login_func(request):
     password_input = request.DATA.get('password', None)
 
     try:
-        # TODO: make sure these fields are sanitized before passing to LDAP server!
         username, email, full_name = connector.login(
             username=login_input, password=password_input)
     except connector.LDAPUserLoginError as ldap_error:


### PR DESCRIPTION
- Sanitize the username using `ldap3`'s `escape_filter_chars` before a filter is built from it.
- Do not do anything about the password, because to the best of my knowledge, no sanitization is needed here (the password should never be interpreted in any way)

## Further resources

* [OWASP LDAP Injection Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html) basically tells to escape the username
* [Stack Overflow answer](https://stackoverflow.com/a/73693762/6377268) that mentions to use `ldap3.utils.conv.escape_filter_chars`
* [`ldap3` documentation](https://ldap3.readthedocs.io/en/latest/searches.html?highlight=escape_filter_chars) mentioning that same function as well